### PR TITLE
Enhance dbservices

### DIFF
--- a/config.properties.template
+++ b/config.properties.template
@@ -2,4 +2,5 @@ dbhost=
 dbname=
 dbschema=
 dbusername=HydraBotDB
-dbpassword=MyHydraBotPassword
+dbpassword=<POSTGRES PASSWORD>
+token=<DISCORD BOT TOKEN>

--- a/config.properties.template
+++ b/config.properties.template
@@ -1,0 +1,5 @@
+dbhost=
+dbname=
+dbschema=
+dbusername=HydraBotDB
+dbpassword=MyHydraBotPassword

--- a/src/main/java/com/stiglmair/hydra/dbservices/DBService.java
+++ b/src/main/java/com/stiglmair/hydra/dbservices/DBService.java
@@ -21,42 +21,110 @@ import java.util.logging.Logger;
 public class DBService {
 
     Connection con;
-    private static final String TABLENAME = "HydraBotDB";
+    private String schema;
 
-    public DBService(String username, String password) {
+    /**
+     * Create a new {@link DbService} from the specified parameters.
+     *
+     * @param dbhost   The host name of the database server. Pass an empty
+     *                 string to automatically fallback on "localhost".
+     * @param dbport   The port of the database server. Pass zero to fallback
+     *                 on the port configured with the `PGPORT` environment
+     *                 variable or 5432 (postgres default port).
+     * @param dbname   The name of the database to connect to (one server
+     *                 can supply multiple databases with different names).
+     *                 Pass an empty string to fallback on the value of the
+     *                 `PGDATABASE` environment variable.
+     * @param schema   The name of the database schema to connect to (the
+     *                 default postgres schema is "public"). Pass an empty
+     *                 string to fallback on the value of the `PGSCHEMA`
+     *                 environment variable.
+     * @param username The name of the user. Pass an empty string to fallback
+     *                 on the `PGUSER` environment variable.
+     * @param password The user's password.
+     */
+    public DBService(String dbhost, int dbport, String dbname,
+                     String schema, String username, String password)
+    {
+        if (dbhost == null || dbhost.isEmpty()) {
+            dbhost = System.getenv("PGHOST");
+            if (dbhost == null || dbhost.isEmpty()) {
+                dbhost = "localhost";
+            }
+        }
+        if (dbport == 0) {
+            String portString = System.getenv("PGPORT");
+            if (portString != null && !portString.isEmpty()) {
+                try {
+                    dbport = Integer.parseInt(portString);
+                } catch (NumberFormatException e) {
+                    String msg = "Invalid value for PGPORT='" + portString + "'.";
+                    Logger.getGlobal().log(Level.SEVERE, msg, e);
+                    throw new RuntimeException(msg);
+                }
+            }
+            else {
+                dbport = 5432;
+            }
+        }
+        if (username == null || username.isEmpty()) {
+            username = System.getenv("PGUSER");
+            if (username == null || username.isEmpty()) {
+                String msg = "Missing value for PGUSER.";
+                Logger.getGlobal().log(Level.SEVERE, msg);
+                throw new RuntimeException(msg);
+            }
+        }
+        if (dbname == null || dbname.isEmpty()) {
+            dbname = System.getenv("PGDATABASE");
+            if (dbname == null || dbname.isEmpty()) {
+                dbname = username;
+            }
+        }
+
+        // Check if the PostgreSQL driver is available.
         try {
             Class.forName("org.postgresql.Driver");
         } catch (ClassNotFoundException ex) {
-            Logger.getGlobal().log(Level.SEVERE, "Error while testing classname.", ex);
+            Logger.getGlobal().log(Level.SEVERE, "PostgreSQL driver not found.", ex);
+            throw new RuntimeException("PostgreSQL driver not found.");
         }
+
+        // Construct the JDBC connection URL.
+        String url = "jdbc:postgresql://" + dbhost + ":" + dbport + "/" + dbname;
+        if (!schema.isEmpty()) {
+            url += "?currentSchema=" + schema;
+        }
+
+        Logger.getGlobal().log(Level.INFO, "Connecting to database (" + url + ") as '" + username + "'.");
         try {
-            con = DriverManager.getConnection("jdbc:postgresql:" + TABLENAME,
-                    username,
-                    password);
+            con = DriverManager.getConnection(url, username, password);
             con.setAutoCommit(true);
         } catch (SQLException ex) {
             Logger.getGlobal().log(Level.SEVERE, "Error during  connection to database.", ex);
         }
+
+        this.schema = schema;
     }
 
     public UserService getUserService() {
-        return new UserService(TABLENAME, con);
+        return new UserService(schema, con);
     }
 
     public GameService getGameService() {
-        return new GameService(TABLENAME, con);
+        return new GameService(schema, con);
     }
 
     public SoundService getSoundService() {
-        return new SoundService(TABLENAME, con);
+        return new SoundService(schema, con);
     }
 
     public BinsenweisheitenService getBinsenweisheitenService() {
-        return new BinsenweisheitenService(TABLENAME, con);
+        return new BinsenweisheitenService(schema, con);
     }
 
     public FlameForDanielService getFlameForDanielService() {
-        return new FlameForDanielService(TABLENAME, con);
+        return new FlameForDanielService(schema, con);
     }
 
     /**

--- a/src/main/java/com/stiglmair/hydra/main/Main.java
+++ b/src/main/java/com/stiglmair/hydra/main/Main.java
@@ -145,9 +145,14 @@ public class Main {
                 properties.load(inStream);
             } catch (IOException e) {
             }
-            String username = properties.getProperty("dbusername");
-            String dbpassword = properties.getProperty("dbpassword");
-            dbService = new DBService(username, dbpassword);
+            dbService = new DBService(
+                properties.getProperty("dbhost"),
+                0,
+                properties.getProperty("dbname"),
+                properties.getProperty("dbschema", "HydraBotDB"),
+                properties.getProperty("dbusername"),
+                properties.getProperty("dbpassword")
+            );
             Token = properties.getProperty("token");
         }
     }


### PR DESCRIPTION
This is a running PR that aims to make enhancements to the `dbservices` API.

Current changes:

* Support `dbhost, dbport, dbname, schema` parameter in `DBService` constructor, with appropriate
  fallbacks
* Raise `RuntimeException`s rather than log & continue (see #6, although in this specific case, I would like to raise a proper exception that can be handled gracefully in the `Main` class, coming soon<sup>TM</sup>)
* Support these options when reading the configuration file, respectively (except `dbport`)